### PR TITLE
Fix light blue text on dark blue background when create_option is on

### DIFF
--- a/chosen/chosen.css
+++ b/chosen/chosen.css
@@ -264,6 +264,13 @@
   background-image: linear-gradient(#3875d7 20%, #2a62bc 90%);
   color: #fff;
 }
+.chzn-container .chzn-results a {
+  color: #444444;
+}
+.chzn-container .chzn-results .highlighted a {
+  color: #fff;
+  text-decoration: none;
+}
 .chzn-container .chzn-results li em {
   background: #feffde;
   font-style: normal;


### PR DESCRIPTION
create_option is on a new line is visible:
`<li class="create-option active-result">
 <a href="javascript:void(0);">' + this.create_option_text + '</a>: "' + terms + '"
</li>`

This "a" has default style - light blue. The selection is dark blue - text is not visible anymore.
